### PR TITLE
Update bootstrap-table-cookie.js

### DIFF
--- a/src/extensions/cookie/bootstrap-table-cookie.js
+++ b/src/extensions/cookie/bootstrap-table-cookie.js
@@ -156,7 +156,7 @@
 
         if (columnsStateSave) {
             $.each(this.options.columns, function (i, column) {
-                column.visible = columnsStateSave.indexOf(i) !== -1;
+                column.visible = columnsStateSave.indexOf(column.field) !== -1;
             });
         }
 
@@ -211,7 +211,7 @@
 
         $.each(this.options.columns, function (i) {
             if (this.visible) {
-                visibleColumns.push(i);
+                visibleColumns.push(this.field);
             }
         });
 


### PR DESCRIPTION
Fixed how the visibleColumn cookie is saved by using field instead of column number. Using column number would result in issues if columns were added to the table after a user already had a cookie in place.